### PR TITLE
終了するときにエラーメッセージが表示されないようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ pip install git+https://github.com/tanakaht/easyautotrans
 ```
 $ easy-auto-trans
 ```
+
+Pressing `Ctrl+C` to exit this program.

--- a/easyautotrans/easyautotrans.py
+++ b/easyautotrans/easyautotrans.py
@@ -26,17 +26,21 @@ def create_parser():
 # clip変更のたびfunc(clip)実行
 def watch_clipboard(func):
     clip_tmp = pyperclip.paste()
-    while True:
-        clip_now = pyperclip.paste()
-        if clip_tmp == clip_now:
-            continue
-        try:
-            print("copied")
-            func(text=clip_now)
-        except Exception as e:
-            print(e)
-        clip_tmp = clip_now
-        time.sleep(1)
+    try:
+        while True:
+            clip_now = pyperclip.paste()
+            if clip_tmp == clip_now:
+                continue
+            try:
+                print("copied")
+                func(text=clip_now)
+            except Exception as e:
+                print(e)
+            clip_tmp = clip_now
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("\nBye.")
+        sys.exit(0)
 
 
 def modify_text_for_trancerate(text):


### PR DESCRIPTION
`Ctrl+c`したときにエラーのログが表示されないようにして代わりに`Bye.`を表示させるようにしました。