### PR TITLE
CRLF/CRに対応

### DIFF
--- a/easyautotrans/easyautotrans.py
+++ b/easyautotrans/easyautotrans.py
@@ -52,7 +52,9 @@ def modify_text_for_translate(input_text):
     dic = {
         '- ': '', # 行区切りのハイフンを全消去
         '-\n': '',
-        '\n': ' ' # 改行->空白変換
+        '\n': ' ',# 改行->空白変換
+        '\r': '', # Windows由来のCRを全消去
+        '-\r\n': '',
     }
     prg = re.compile('|'.join(dic.keys()))
     formatter = lambda match: dic[match.group(0)]

--- a/easyautotrans/easyautotrans.py
+++ b/easyautotrans/easyautotrans.py
@@ -51,10 +51,15 @@ def watch_clipboard(func, on_color=None):
 def modify_text_for_translate(input_text):
     dic = {
         '- ': '', # 行区切りのハイフンを全消去
-        '-\n': '',
-        '\n': ' ',# 改行->空白変換
-        '\r': '', # Windows由来のCRを全消去
-        '-\r\n': '',
+    	# for CRLF
+    	'-\r\n': '', # 行区切りのハイフン除去
+    	'\r\n': ' ', # 改行->空白変換
+    	# for CR
+    	'-\r': '', # 行区切りのハイフン除去
+    	'\r': ' ', # 改行->空白変換
+    	# for LF
+        '-\n': '', # 行区切りのハイフン除去
+        '\n': ' '  # 改行->空白変換
     }
     prg = re.compile('|'.join(dic.keys()))
     formatter = lambda match: dic[match.group(0)]


### PR DESCRIPTION
翻訳文章の前処理時にCRLF/CRを考慮するように変更しました。

以下の環境で改行が正しく空白に置き換えられたことを確認しました。

| python実行環境 | テキストコピー環境 | テキストコピー元ソフトウェア | 改行コード |
| --- | --- | --- | --- |
| macOS Mojave | macOS Mojave | Google Chrome | LF |
| macOS Mojave | macOS Mojave | Adobe Acrobat Reader | CR |
| Ubuntu 18.04 (WSL) | Windows 10 | Google Chrome | CRLF |

参考: Issue #16